### PR TITLE
Added commands for showing/toggling state

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can activate pry-state on the current binding with the command `show-state`.
 
 You can turn on the state display as the default by adding this to your `.pryrc`:
 
-`Pry.config.pry_state.hook_enabled = true`
+`Pry.config.state_hook_enabled = true`
 
 ## Customisation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Or install it yourself as:
 
 ## Usage
 
-There is no need to edit any configuration. After you have added the dependency in Gemfile, pry-state will add a hook to pry to listen to before_session events.
+You can activate pry-state on the current binding with the command `show-state`. You can also toggle displaying the state at each binding change event with `toggle-state`. This is useful for debugging, such as with [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug).
+
+You can turn on the state display as the default by adding this to your `.pryrc`:
+
+`Pry.config.pry_state.hook_enabled = true`
 
 ## Customisation
 

--- a/lib/pry-state.rb
+++ b/lib/pry-state.rb
@@ -3,6 +3,8 @@ require "pry-state/version"
 require 'pry-state/hook_action'
 require 'pry-state/commands'
 
+# Will the state be displayed automatically?
+Pry.config.state_hook_enabled ||= false
 
 Pry.hooks.add_hook(:before_session, "pry_state_hook") do |output, binding, pry|
   HookAction.new(binding, pry).act

--- a/lib/pry-state.rb
+++ b/lib/pry-state.rb
@@ -1,6 +1,7 @@
 require "pry"
 require "pry-state/version"
 require 'pry-state/hook_action'
+require 'pry-state/commands'
 
 
 Pry.hooks.add_hook(:before_session, "pry_state_hook") do |output, binding, pry|

--- a/lib/pry-state/commands.rb
+++ b/lib/pry-state/commands.rb
@@ -1,0 +1,9 @@
+PryState::Commands = Pry::CommandSet.new
+
+command_glob = File.expand_path('../commands/*.rb', __FILE__)
+
+Dir[command_glob].each do |command|
+  require command
+end
+
+Pry.commands.import PryState::Commands

--- a/lib/pry-state/commands/show_state.rb
+++ b/lib/pry-state/commands/show_state.rb
@@ -1,0 +1,19 @@
+class PryState::ShowState < Pry::ClassCommand
+  match "show-state"
+  group "pry-state"
+  description "Show the current binding state."
+
+  def options(opt)
+    opt.banner unindent <<-USAGE
+      Usage: show-state
+
+      show-state will show the current binding state.
+    USAGE
+  end
+
+  def process
+    HookAction.new(target, _pry_).act(true)
+  end
+end
+
+PryState::Commands.add_command PryState::ShowState

--- a/lib/pry-state/commands/show_state.rb
+++ b/lib/pry-state/commands/show_state.rb
@@ -8,6 +8,8 @@ class PryState::ShowState < Pry::ClassCommand
       Usage: show-state
 
       show-state will show the current binding state.
+
+      Use `toggle-state` to turn on automatic state display on stack change.
     USAGE
   end
 

--- a/lib/pry-state/commands/show_state.rb
+++ b/lib/pry-state/commands/show_state.rb
@@ -9,7 +9,7 @@ class PryState::ShowState < Pry::ClassCommand
 
       show-state will show the current binding state.
 
-      Use `toggle-state` to turn on automatic state display on stack change.
+      Use `toggle-state` to turn on automatic state display.
     USAGE
   end
 

--- a/lib/pry-state/commands/toggle_state.rb
+++ b/lib/pry-state/commands/toggle_state.rb
@@ -1,0 +1,28 @@
+class PryState::ToggleState < Pry::ClassCommand
+  match "toggle-state"
+  group "pry-state"
+  description "Toggle automatic pry-State display."
+
+  def options(opt)
+    opt.banner unindent <<-USAGE
+      Usage: toggle-state
+
+      toggle-state will toggle automatic state display. Off by default.
+      Set `Pry.config.pry_state.hook_enabled = true` in your config file to
+      always turn it on.
+
+      Use `show-state` to just show the current state.
+    USAGE
+  end
+
+  def process
+    if Pry.config.pry_state.hook_enabled ^= true
+      output.puts "pry-state enabled."
+      HookAction.new(target, _pry_).act
+    else
+      output.puts "pry-state disabled."
+    end
+  end
+end
+
+PryState::Commands.add_command PryState::ToggleState

--- a/lib/pry-state/commands/toggle_state.rb
+++ b/lib/pry-state/commands/toggle_state.rb
@@ -8,17 +8,17 @@ class PryState::ToggleState < Pry::ClassCommand
       Usage: toggle-state
 
       toggle-state will toggle automatic state display. Off by default.
-      Set `Pry.config.pry_state.hook_enabled = true` in your config file to
-      always turn it on.
+      Set `Pry.config.state_hook_enabled = true` in your .pryrc file to
+      permanently enable it.
 
-      Use `show-state` to just show the current state.
+      Use `show-state` to show the current state.
     USAGE
   end
 
   def process
-    if Pry.config.pry_state.hook_enabled ^= true
+    if Pry.config.state_hook_enabled ^= true
       output.puts "pry-state enabled."
-      HookAction.new(target, _pry_).act
+      HookAction.new(target, Pry).act
     else
       output.puts "pry-state disabled."
     end

--- a/lib/pry-state/hook_action.rb
+++ b/lib/pry-state/hook_action.rb
@@ -10,9 +10,12 @@ class HookAction
 
   def initialize binding, pry
     @binding, @pry = binding, pry
+    Pry.config.pry_state.hook_enabled ||= false
   end
 
-  def act
+  def act(force = false)
+    return unless force || Pry.config.pry_state.hook_enabled
+
     # when using guard, locals :e, :lib, :pry_state_prev get printed.
     # this 'if' cuts them off.
     if @binding.eval("self.class") == Object

--- a/lib/pry-state/hook_action.rb
+++ b/lib/pry-state/hook_action.rb
@@ -10,11 +10,10 @@ class HookAction
 
   def initialize binding, pry
     @binding, @pry = binding, pry
-    Pry.config.pry_state.hook_enabled ||= false
   end
 
   def act(force = false)
-    return unless force || Pry.config.pry_state.hook_enabled
+    return unless force || Pry.config.state_hook_enabled
 
     # when using guard, locals :e, :lib, :pry_state_prev get printed.
     # this 'if' cuts them off.

--- a/spec/lib/pry-state/commands/show_state_spec.rb
+++ b/spec/lib/pry-state/commands/show_state_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe "show-state" do
+  it "prints local variables" do
+    test_string = "secret message"
+
+    output = capture_pry_command("show-state", binding)
+
+    expect(output).to include %(\e[0;36mtest_string          \e[0m\e[0;37m\"secret message\"\e[0m\n)
+  end
+
+  it "prints instance variables" do
+    @instance_test = "#winning"
+
+    output = capture_pry_command("show-state", binding)
+
+    expect(output).to include %(\e[0;32m@instance_test       \e[0m\e[0;37m\"#winning\"\e[0m\n)
+  end
+
+  it "prints objects" do
+    test_object = Object.new
+
+    output = capture_pry_command("show-state", binding)
+
+    expect(output).to include %(\e[0;36mtest_object          \e[0m\e[0;37m#{test_object}\e[0m\n)
+  end
+
+  it "doesn't print constants" do
+    TestMe = Struct.new(:one, :two)
+
+    output = capture_pry_command("show-state", binding)
+
+    expect(output).not_to include "TestMe"
+  end
+
+  context "when hook_enabled=false" do
+    before { Pry.config.state_hook_enabled = false }
+
+    it "prints state" do
+      test_object = Object.new
+
+      output = capture_pry_command("show-state", binding)
+
+      expect(output).to include %(\e[0;36mtest_object          \e[0m\e[0;37m#{test_object}\e[0m\n)
+    end
+  end
+end

--- a/spec/lib/pry-state/commands/toggle_state_spec.rb
+++ b/spec/lib/pry-state/commands/toggle_state_spec.rb
@@ -2,22 +2,24 @@ require "spec_helper"
 
 RSpec.describe "toggle-state" do
   context "when the hook is enabled" do
-    before { Pry.config.state_hook_enabled = true }
+    before { allow(Pry.config).to receive(:state_hook_enabled).and_return(true) }
 
     it "sets the hook config to be disabled" do
+      expect(Pry.config).to receive(:state_hook_enabled=).with(false)
       output = capture_pry_command("toggle-state", binding)
       expect(output).to include "pry-state disabled."
-      expect(Pry.config.state_hook_enabled).to eq false
     end
   end
 
   context "when the hook is disabled" do
-    before { Pry.config.state_hook_enabled = false }
+    before { allow(Pry.config).to receive(:state_hook_enabled).and_return(false) }
 
     it "sets the hook config to be enabled" do
+      # If the developer has `Pry.config.state_hook_enabled = true` in their
+      # .pryrc, this expectation will get called twice; take that into account
+      expect(Pry.config).to receive(:state_hook_enabled=).with(true).at_least(:once)
       output = capture_pry_command("toggle-state", binding)
       expect(output).to include "pry-state enabled."
-      expect(Pry.config.state_hook_enabled).to eq true
     end
   end
 end

--- a/spec/lib/pry-state/commands/toggle_state_spec.rb
+++ b/spec/lib/pry-state/commands/toggle_state_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe "toggle-state" do
+  context "when the hook is enabled" do
+    before { Pry.config.state_hook_enabled = true }
+
+    it "sets the hook config to be disabled" do
+      output = capture_pry_command("toggle-state", binding)
+      expect(output).to include "pry-state disabled."
+      expect(Pry.config.state_hook_enabled).to eq false
+    end
+  end
+
+  context "when the hook is disabled" do
+    before { Pry.config.state_hook_enabled = false }
+
+    it "sets the hook config to be enabled" do
+      output = capture_pry_command("toggle-state", binding)
+      expect(output).to include "pry-state enabled."
+      expect(Pry.config.state_hook_enabled).to eq true
+    end
+  end
+end

--- a/spec/lib/pry-state/hook_action_spec.rb
+++ b/spec/lib/pry-state/hook_action_spec.rb
@@ -2,18 +2,45 @@ require 'spec_helper'
 require 'ostruct'
 
 RSpec.describe HookAction do
-  context "When a binding.pry called" do
+  # create a sticky locals hash with different @b value to get it in green color
+  let(:pry_mock) { OpenStruct.new(config: OpenStruct.new(extra_sticky_locals: { pry_state_prev: { :@b => 'wd' } })) }
+
+  context "when hook is disabled" do
+    before { Pry.config.state_hook_enabled = false }
+
+    it "doesn't print anything" do
+      output = capture_stdout do
+        HookAction.new(anything, anything).act
+      end
+      expect(output).to be_empty
+    end
+
+    context "when force is true" do
+      it "prints the current state" do
+        user = "Superman"
+        output = capture_stdout do
+          HookAction.new(binding, pry_mock).act(true)
+        end
+        line = output.lines.find { |l| l.include? "user" }
+        expect(line).not_to be_nil
+        expect(line).to include "Superman"
+      end
+    end
+  end
+
+  context "when hook is enabled" do
+    before { Pry.config.state_hook_enabled = true }
+
     # begin/end codes for bright_yellow
-    let(:val_chg_begin_code) {"\e[0m\e[1;33m"}
+    let(:val_chg_begin_code) { "\e[0m\e[1;33m" }
     let(:val_chg_end_code) { "\e[0m\n\e[0;32m@c" }
-    it "should print the current state" do
+
+    it "prints the current state" do
       a = 1
       @b = "world"
       @c = [1, 2, 4, 5]
-      # create a sticky locals hash with different @b value to get it in green color
-      pry = OpenStruct.new(:config=>OpenStruct.new(:extra_sticky_locals=>{:pry_state_prev=>{:@b=>'wd'}}))
       output = capture_stdout do
-        HookAction.new(binding, pry).act
+        HookAction.new(binding, pry_mock).act
       end
 
       expect(output).to include 'a'


### PR DESCRIPTION
Adds two commands to pry-state

- `show-state` will show the state at the current location
- `toggle-state` will toggle on/off the automatic state showing.

Since the user can manually toggle this, displaying the state is off by default (this is a change from the current settings). The user can manually set the configuration in their .pryrc, which is described in the updated README.