### PR TITLE
Fix the ReadMe screenshot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ When you are debugging, you care about the state of your program. You want to in
 
 Pry state is an extension of pry. With pry state you can see the values of the instance and local variables in a pry session.
 
-![SCREENSHOT] (https://cloud.githubusercontent.com/assets/1620848/9140567/d57047a4-3d4f-11e5-901e-d508c01c8d52.png)
+![SCREENSHOT](https://cloud.githubusercontent.com/assets/1620848/9140567/d57047a4-3d4f-11e5-901e-d508c01c8d52.png)
 
 ## Installation
 


### PR DESCRIPTION
The screenshot wasn't rendering on the ReadMe because a space between the alt text and image link.